### PR TITLE
fix: path with params doesnt match

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -46,7 +46,7 @@ export default [
     ],
     output: {
       name: 'framework',
-      file: pkg.browser,
+      file: pkg.unpkg,
       format: 'umd',
       sourcemap: true,
       globals: {

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,16 +16,12 @@ export function createBrowserApplication(config: {
   const navigation = createNavigation(domain);
   forward({ from: config.ready, to: navigation.historyEmitCurrent });
 
-  const routesMatched = navigation.historyChanged.map((change) => ({
-    routes: matchRoutes(config.routes, change.pathname),
-    change,
-  }));
+  const routeResolved = navigation.historyChanged.filterMap((change) => {
+    const routes = matchRoutes(config.routes, change.pathname);
 
-  const routeResolved = routesMatched.filterMap(({ routes, change }) => {
-    const found = routes.find((route) => route.route.path === change.pathname);
-    if (found) {
+    if (routes.length > 0) {
       return {
-        ...found,
+        ...routes[0],
         change,
       };
     }


### PR DESCRIPTION
- В routeResolved в `route.route.path === change.pathname` сравнивались шаблон с `:id` и реальный путь с подставленным значением, соответственно enter ивент на хетче никогда не срабатывал если путь содержал параметр
- ранее в package поле browser было заменено на unpkg, нужно это же изменение поддержать в конфиге роллапа, иначе не работает сборка